### PR TITLE
Add and remove units from the selection with shift. #81

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -104,6 +104,11 @@ move_map_right={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
 ]
 }
+shift_selecting={
+"deadzone": 0.5,
+"events": [null, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
 
 [internationalization]
 

--- a/source/match/Match.gd
+++ b/source/match/Match.gd
@@ -50,6 +50,8 @@ func _ready():
 
 func _unhandled_input(event):
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+		if(Input.is_action_pressed("shift_selecting")):
+			return
 		MatchSignals.deselect_all_units.emit()
 
 

--- a/source/match/handlers/SelectionHandler.gd
+++ b/source/match/handlers/SelectionHandler.gd
@@ -47,7 +47,7 @@ func _get_controlled_units_from_navigation_domain_within_topdown_polygon_2d(
 
 
 func _select_units(units_to_select):
-	if not units_to_select.empty():
+	if not units_to_select.empty() && not Input.is_action_pressed("shift_selecting"):
 		MatchSignals.deselect_all_units.emit()
 	for unit in units_to_select.iterate():
 		var selection = unit.find_child("Selection")

--- a/source/match/units/traits/Selection.gd
+++ b/source/match/units/traits/Selection.gd
@@ -77,4 +77,7 @@ func _update_circle_params():
 
 func _on_input_event(_camera, event, _click_position, _click_normal, _shape_idx):
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+		if(_selected and Input.is_action_pressed("shift_selecting")):
+			deselect()
+			return
 		select()


### PR DESCRIPTION
I added the shift button/action to the project settings and used it follow what the issue was requesting. 

> * Holding shift and box selecting units should add them to the current selection.
> 
> * Holding shift and clicking on a unit should add it to the selection
> 
> * Holding shift and clicking on an already selected unit should remove it from the selection


