### PR TITLE
suggestion: inform units on receiving hit

### DIFF
--- a/source/match/MatchSignals.gd
+++ b/source/match/MatchSignals.gd
@@ -12,3 +12,5 @@ signal unit_targeted(unit)
 signal unit_selected(unit)
 signal unit_deselected(unit)
 signal unit_died(unit)
+
+signal attacked_by(unit, attacker)

--- a/source/match/units/Unit.gd
+++ b/source/match/units/Unit.gd
@@ -39,6 +39,8 @@ var action = null:
 
 var _action_locked = false
 
+var _auxillary_target = null
+
 @onready var _match = find_parent("Match")
 
 
@@ -47,6 +49,9 @@ func _ready():
 		await _match.ready
 	_setup_color()
 	_setup_default_properties_from_constants()
+
+	MatchSignals.attacked_by.connect(_on_friendly_attacked)
+
 	assert(_safety_checks())
 
 
@@ -167,3 +172,9 @@ func _setup_default_properties_from_constants():
 func _on_action_node_tree_exited(action_node):
 	assert(action_node == action, "unexpected action released")
 	action = null
+
+
+func _on_friendly_attacked(attacked, target):
+	if self.player == attacked.player:
+		if self.position.distance_to(attacked.position) <= self.sight_range:
+			_auxillary_target = target

--- a/source/match/units/actions/WaitingForTargets.gd
+++ b/source/match/units/actions/WaitingForTargets.gd
@@ -28,7 +28,8 @@ func is_idle():
 
 func _get_units_to_attack():
 	var self_position_yless = _unit.global_position * Vector3(1, 0, 1)
-	return get_tree().get_nodes_in_group("units").filter(
+
+	var units_to_attack = get_tree().get_nodes_in_group("units").filter(
 		func(unit): return (
 			unit.player != _unit.player
 			and unit.movement_domain in _unit.attack_domains
@@ -38,6 +39,12 @@ func _get_units_to_attack():
 			)
 		)
 	)
+
+	if units_to_attack.is_empty():
+		if _unit._auxillary_target != null:
+			units_to_attack.append(_unit._auxillary_target)
+
+	return units_to_attack
 
 
 func _attack_unit(unit):

--- a/source/match/units/projectiles/CannonShell.gd
+++ b/source/match/units/projectiles/CannonShell.gd
@@ -12,6 +12,7 @@ func _ready():
 	_unit_particles.visible = _unit.visible
 	_setup_unit_particles()
 	_setup_timer()
+	MatchSignals.attacked_by.emit(target_unit, _unit)
 	target_unit.hp -= _unit.attack_damage
 
 


### PR DESCRIPTION
I was toying this idea as an alternative to handle https://github.com/lampe-games/godot-open-rts/issues/95 & make the actors more responsive to each other.
I was not sold on, units auto attacking in sight range, seems a bit too offensive to me, so here is the idea for a Defend Your Friend doctrine. 

To be honest I am not sure if this does anything right now, I will try to test it out soon ™️  

Right now it should act as a defensive reaction, where units support each other, but could also be added to the offensive stances.

If you like it, the do adjust would be the following:

- [ ] adjust the signal for offensive stance
- [ ] don't set auxiliary target on workers
- [ ] possibly filter signals by team