### PR TITLE
Unit selection groups

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -109,6 +109,96 @@ shift_selecting={
 "events": [null, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
+unit_groups_set_1={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":49,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+unit_groups_set_2={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":50,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+unit_groups_set_3={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":51,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+unit_groups_set_4={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":52,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+unit_groups_set_5={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":53,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+unit_groups_set_6={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":54,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+unit_groups_set_7={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":55,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+unit_groups_set_8={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":56,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+unit_groups_set_9={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":57,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+unit_groups_access_1={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":49,"key_label":0,"unicode":49,"echo":false,"script":null)
+]
+}
+unit_groups_access_2={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":50,"key_label":0,"unicode":50,"echo":false,"script":null)
+]
+}
+unit_groups_access_3={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":51,"key_label":0,"unicode":51,"echo":false,"script":null)
+]
+}
+unit_groups_access_4={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":52,"key_label":0,"unicode":52,"echo":false,"script":null)
+]
+}
+unit_groups_access_5={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":53,"key_label":0,"unicode":53,"echo":false,"script":null)
+]
+}
+unit_groups_access_6={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":54,"key_label":0,"unicode":54,"echo":false,"script":null)
+]
+}
+unit_groups_access_7={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":55,"key_label":0,"unicode":55,"echo":false,"script":null)
+]
+}
+unit_groups_access_8={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":56,"key_label":0,"unicode":56,"echo":false,"script":null)
+]
+}
+unit_groups_access_9={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":57,"key_label":0,"unicode":57,"echo":false,"script":null)
+]
+}
 
 [internationalization]
 

--- a/source/match/Match.tscn
+++ b/source/match/Match.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=44 format=3 uid="uid://camns8fqod8d4"]
+[gd_scene load_steps=45 format=3 uid="uid://camns8fqod8d4"]
 
 [ext_resource type="Script" path="res://source/match/Match.gd" id="1_1555u"]
 [ext_resource type="Script" path="res://source/match/IsometricCamera3D.gd" id="1_qb2ry"]
@@ -27,6 +27,7 @@
 [ext_resource type="PackedScene" uid="uid://bocb7hjilvri5" path="res://source/match/handlers/ArealUnitSelectionHandler.tscn" id="24_aug7m"]
 [ext_resource type="PackedScene" uid="uid://pi813oou7xim" path="res://source/match/handlers/DoubleClickUnitSelectionHandler.tscn" id="25_ldkhw"]
 [ext_resource type="PackedScene" uid="uid://yn470qvc3eak" path="res://source/match/handlers/MatchEndHandler.tscn" id="26_4d7im"]
+[ext_resource type="PackedScene" uid="uid://ck6vrgdyg7hja" path="res://source/match/handlers/UnitGroupSelectionHandler.tscn" id="27_j2drv"]
 [ext_resource type="PackedScene" uid="uid://b8p6lcwubx1tp" path="res://source/match/handlers/UnitVisibilityHandler.tscn" id="32_fci1c"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_ysb0j"]
@@ -417,6 +418,8 @@ rectangular_selection_3d = NodePath("../../RectangularSelection3D")
 [node name="DoubleClickUnitSelectionHandler" parent="Handlers" instance=ExtResource("25_ldkhw")]
 
 [node name="MouseClickAnimationsHandler" parent="Handlers" instance=ExtResource("22_438pb")]
+
+[node name="UnitGroupSelectionHandler" parent="Handlers" instance=ExtResource("27_j2drv")]
 
 [node name="MatchEndHandler" parent="Handlers" instance=ExtResource("26_4d7im")]
 visible = false

--- a/source/match/handlers/UnitGroupSelectionHandler.gd
+++ b/source/match/handlers/UnitGroupSelectionHandler.gd
@@ -1,0 +1,65 @@
+extends Node3D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass
+
+func _input(event):
+	if event.is_action_pressed("unit_groups_set_1"):
+		set_group(1)
+	elif event.is_action_pressed("unit_groups_set_2"):
+		set_group(2)
+	elif event.is_action_pressed("unit_groups_set_3"):
+		set_group(3)
+	elif event.is_action_pressed("unit_groups_set_4"):
+		set_group(4)
+	elif event.is_action_pressed("unit_groups_set_5"):
+		set_group(5)
+	elif event.is_action_pressed("unit_groups_set_6"):
+		set_group(6)
+	elif event.is_action_pressed("unit_groups_set_7"):
+		set_group(7)
+	elif event.is_action_pressed("unit_groups_set_8"):
+		set_group(8)
+	elif event.is_action_pressed("unit_groups_set_9"):
+		set_group(9)
+	elif event.is_action_pressed("unit_groups_access_1"):
+		access_group(1)
+	elif event.is_action_pressed("unit_groups_access_2"):
+		access_group(2)
+	elif event.is_action_pressed("unit_groups_access_3"):
+		access_group(3)
+	elif event.is_action_pressed("unit_groups_access_4"):
+		access_group(4)
+	elif event.is_action_pressed("unit_groups_access_5"):
+		access_group(5)
+	elif event.is_action_pressed("unit_groups_access_6"):
+		access_group(6)
+	elif event.is_action_pressed("unit_groups_access_7"):
+		access_group(7)
+	elif event.is_action_pressed("unit_groups_access_8"):
+		access_group(8)
+	elif event.is_action_pressed("unit_groups_access_9"):
+		access_group(9)
+
+func access_group(group_id:int):
+	var unit_group = Utils.Set.new()
+	for unit in get_tree().get_nodes_in_group("unit_group_"+str(group_id)):
+		if unit != null:
+			unit_group.add(unit)
+	Utils.Match.select_units(unit_group)
+	
+	
+func set_group(group_id:int):
+	for unit in get_tree().get_nodes_in_group("unit_group_"+str(group_id)):
+		unit.remove_from_group("unit_group_"+str(group_id))
+	var unit_group = get_tree().get_nodes_in_group("selected_units")
+	for unit in unit_group:
+		if unit.is_in_group("controlled_units"):
+			unit.add_to_group("unit_group_"+str(group_id))

--- a/source/match/handlers/UnitGroupSelectionHandler.tscn
+++ b/source/match/handlers/UnitGroupSelectionHandler.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://ck6vrgdyg7hja"]
+
+[ext_resource type="Script" path="res://source/match/handlers/UnitGroupSelectionHandler.gd" id="1_jgs3c"]
+
+[node name="UnitGroupSelectionHandler" type="Node3D"]
+script = ExtResource("1_jgs3c")

--- a/source/match/units/traits/Selection.gd
+++ b/source/match/units/traits/Selection.gd
@@ -45,6 +45,11 @@ func deselect():
 		_unit.deselected.emit()
 	MatchSignals.unit_deselected.emit(_unit)
 
+func assign_group(group_id:int):
+	if _unit.is_in_group("unit_group_"+str(group_id)):
+		return
+	else:
+		_unit.add_to_group("unit_group_"+str(group_id))
 
 func _set_radius(a_radius):
 	radius = a_radius


### PR DESCRIPTION
- allows player to assign units to control groups 1-9 and access those groups
- Implementation with Godot InputMap - seems a bit repetitive but makes sure, that the hotkeys can be easily changed and also adjusted for console play 
- Closes #61 