### PR TITLE
add 3d switcher

### DIFF
--- a/assets/ui/kenney-crosshairs/crosshair001.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair001.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair001.png-ad280f7b64a6726347e7335f2950
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair002.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair002.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair002.png-54ed3f54671f5081cd0b54d7f6db
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair003.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair003.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair003.png-db866447da4b114c2c0090e8e3b7
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair004.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair004.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair004.png-322f74c0a5ba34181dd2cb9eda6b
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair005.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair005.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair005.png-43a96b455f52f68b97973e2b1a0c
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair006.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair006.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair006.png-8d365c829baf8f6c7f417f9614cd
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair007.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair007.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair007.png-ac5171e42340bdab386efa928f58
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair008.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair008.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair008.png-597ce4d6b331e626ee29eefd4e1b
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair009.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair009.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair009.png-2a60a082027ee169460333a190e2
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair010.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair010.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair010.png-b3705597025ce5edd45377f459ba
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair011.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair011.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair011.png-5c0ec0328a6d47892a3baa042b36
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair012.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair012.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair012.png-2820c08d6bb1ec6e6bbc33632618
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair013.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair013.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair013.png-f7c5912b81061030a33fa0a80ca3
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair014.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair014.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair014.png-88ab780df1d52eec3783e96e80ba
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair015.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair015.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair015.png-78d4f3cf4f69821e17a4cc5a45dd
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair016.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair016.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair016.png-8d477e4b208968148abe31fcf470
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair017.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair017.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair017.png-247c52a05de7efd031ec9cfc1425
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair018.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair018.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair018.png-15ee9449110c404961eb1c26a1cb
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair019.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair019.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair019.png-168f6431a94136051943b8c638b9
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair020.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair020.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair020.png-6acc21704d8152119bb48566a3b4
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair021.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair021.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair021.png-c438baf603f881cc92b153829f74
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair022.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair022.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair022.png-2be01d094fd7bb9684c82e230582
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair023.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair023.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair023.png-a11505291ee65aef1a6162ddf06e
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair024.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair024.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair024.png-2f5eb2dea2b5e4c1483493453e83
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair025.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair025.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair025.png-16c5dbf7b0cd986e67cc5d4c5674
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair026.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair026.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair026.png-a084ddcd95678eecf15793005d1b
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair027.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair027.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair027.png-1d228f85212b0c494805530b9485
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair028.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair028.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair028.png-c5f8fea9986374e2e0f7b028818a
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair029.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair029.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair029.png-ec35269c36a0eeaca30141f01abc
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair030.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair030.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair030.png-13cc5cc43688597cc61eb6481ba9
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair031.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair031.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair031.png-e5ff0d25387131cac0f6ad93fbaf
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair032.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair032.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair032.png-15a2e5a72fd1be8e752e479275cc
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair033.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair033.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair033.png-d54f271664bc08596542863db7fa
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair034.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair034.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair034.png-1307a68c7020f79bbc24422272b1
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair035.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair035.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair035.png-c1684a600d1f9fa2f3a07011c5b4
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair036.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair036.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair036.png-9a2c8caec49cb54a010f736b2217
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair037.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair037.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair037.png-17da48542635e979f5d4e051085c
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair038.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair038.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair038.png-a1b242b11fa160a4640098758d3d
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair039.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair039.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair039.png-fa50376266cd009e1b9071be477a
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair040.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair040.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair040.png-1b8144476a63b33ad2446c4be84f
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair041.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair041.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair041.png-c54658ad93b9088692a056f6ec1b
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair042.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair042.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair042.png-93a4243e3ee8f263bd6b4bc2fdfb
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair043.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair043.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair043.png-694b39f77ad1871f8160342f62f9
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair044.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair044.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair044.png-0fcde6f21e7ee85a339abfd020ff
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair045.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair045.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair045.png-71e8c31ee3ec9009aee043dce897
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair046.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair046.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair046.png-a3fb6b9fc3b3ad12715940534c5f
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair047.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair047.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair047.png-7199962d9d1a2004993225127480
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair048.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair048.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair048.png-0d0605f172437b72239900df930d
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair049.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair049.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair049.png-42cefc2c6dec2e839e728b378d6a
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair050.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair050.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair050.png-591e37eeb3bfc40a129f5753edc6
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair051.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair051.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair051.png-a6e32ea76678b616410ffffbcc00
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair052.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair052.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair052.png-e127dc341f8dc5f5d59f6c404152
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair053.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair053.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair053.png-0b7df475e130e8d0ba459c605a0e
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair054.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair054.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair054.png-02f12dcaf1cfb46d9576526b9689
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair055.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair055.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair055.png-45be0f7eef7b1d0a03dc5db98960
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair056.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair056.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair056.png-b632edc58f16b7b939e6be13ed51
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair057.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair057.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair057.png-cbc4d1b87cdafe25157070c0ccc0
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair058.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair058.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair058.png-0a916cdc5e0cd08e01fc354c1d2a
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair059.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair059.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair059.png-ecc9a3f415d31f8b454d88cf19da
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair060.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair060.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair060.png-31803578bfda9fe81afe4a33eb5f
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair061.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair061.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair061.png-35b80125dfd1caf0d8baaebd6024
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair063.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair063.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair063.png-875309258c2abd989fa3d40b7bce
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair064.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair064.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair064.png-f3e0a46e4cd92182538aef6f99d8
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair065.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair065.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair065.png-7f8f4bc257ef1c0049943f745730
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair066.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair066.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair066.png-99d51884b36d7aa1a1388fbb7b16
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair067.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair067.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair067.png-9af70d119fac60cfc1507a3db50c
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair068.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair068.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair068.png-edcc88267a81136d0bbaa8759767
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair069.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair069.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair069.png-ec95c0296ecc6fb1fd768613d820
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair070.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair070.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair070.png-0954852fe9650330f523071b0552
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair071.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair071.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair071.png-02caf31064321af1bae28ad31653
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair072.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair072.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair072.png-a6c1e3e9cc6aade664d11cf65035
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair073.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair073.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair073.png-7222c5c267f123f9a403c24e2f1a
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair074.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair074.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair074.png-63b0ae28c6edc3eb7bb3bd16f30c
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair075.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair075.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair075.png-c8c38207bab03b39d520aa046ffd
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair076.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair076.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair076.png-0d50abfbaaba7c6255827725dd3e
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair077.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair077.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair077.png-c7509c8ac5a738a9cf8bbef46ec2
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair078.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair078.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair078.png-44d215d776626cc4bdf58a3a7886
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair079.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair079.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair079.png-e2f8e52aa784ccc097b0cbe1f9ff
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair080.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair080.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair080.png-f611b80903e3d2f5a88560685ab5
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair081.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair081.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair081.png-9c78bf6e367b6be40893aba8f7b7
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair082.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair082.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair082.png-add56c71870557a84891130e9906
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair083.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair083.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair083.png-9b9a072a7358c02d68cf25469e36
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair084.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair084.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair084.png-7dc5f946aff88d651f2539b79c4f
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair085.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair085.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair085.png-2258b8a2c5dac96d5041fcd792de
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair086.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair086.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair086.png-fece61b29931cfbce5e1f5003f05
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair087.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair087.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair087.png-6a2d9b5cecb5b1d6857406350a95
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair088.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair088.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair088.png-8e9ac13fb60a0e671cd644146b0c
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair089.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair089.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair089.png-3880bbe8da75ed1689ae35d7b790
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair090.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair090.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair090.png-acd588722e79f80bca45e264c795
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair091.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair091.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair091.png-aa3542bbeb5cf9282a9dc3f6f405
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair092.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair092.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair092.png-a1347aa8eaf04d52cff553270523
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair093.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair093.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair093.png-3e7bf4622af939a572f30d88964f
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair094.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair094.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair094.png-b01e429bbdc21b30d88d4fe4177a
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair095.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair095.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair095.png-57ffce81cfbaf330748e050b86a6
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair096.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair096.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair096.png-f48d6c7981333034a3f6929bd18b
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair097.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair097.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair097.png-a068a878333a5a8f5b9f3335e836
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair098.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair098.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair098.png-0a246198be1796de34f2f43ede9a
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair099.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair099.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair099.png-baae316d241729025b81fbaa8b5e
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair100.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair100.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair100.png-1a96df6f2747bcf167f8c9a2065f
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair101.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair101.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair101.png-47099b6c3bd80e2d36a75961ed46
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair102.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair102.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair102.png-01fd7efaf91bbf82709dbac95260
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair103.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair103.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair103.png-e22dd13bcc71adcfdd6a06775160
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair104.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair104.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair104.png-028f7b05844cfbfdcbe79b84fa9f
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair105.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair105.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair105.png-d050e96e8b190fb2e2fa647f4d1a
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair106.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair106.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair106.png-37cdadcdb4c890589f2e1186ad26
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair107.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair107.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair107.png-c22de6b038a4aa84ef5e1d5041c4
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair108.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair108.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair108.png-ea6f9981f38938e0d1e01b41976a
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair109.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair109.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair109.png-b64f619ed740d4bfbdb9ebb639c6
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair110.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair110.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair110.png-f915cd21e9ea05a649e087975db8
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair111.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair111.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair111.png-977729966da1f53357ec6dd7b5c6
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair112.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair112.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair112.png-917c80e2d0a04c3ac108df95dd75
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair113.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair113.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair113.png-2a1ea6e9aff511e1cc1882739402
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair114.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair114.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair114.png-6e30e6c981eab7675ba7269a976b
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair115.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair115.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair115.png-61a447e7a1c17f9a03ec8d539844
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair116.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair116.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair116.png-3e14ec865088d6c253d33f438a56
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair117.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair117.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair117.png-8b853b615a27e28ecdb60e20ba83
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair118.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair118.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair118.png-3ad4455789271334cb00a8706a77
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair119.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair119.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair119.png-47fb6661b49be2f4324f239db730
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair120.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair120.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair120.png-68515202c2ebc10e565a25e9b6ee
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair121.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair121.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair121.png-47675d40db3f0601ad0d6f31946c
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair122.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair122.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair122.png-49ab0b295dfafe8640e1677dda20
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair123.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair123.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair123.png-bb14418ad6f73b3affb067737f8c
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair124.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair124.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair124.png-53c60f9128199e99f6384c558930
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair125.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair125.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair125.png-52c2a8b8cc20aaf395e8188cf0bb
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair126.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair126.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair126.png-f968364768652e4d2469b92d1e84
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair127.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair127.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair127.png-e8b4946efc37be72fac72af35323
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair128.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair128.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair128.png-08f3dd98eab88413bb02a06275fb
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair129.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair129.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair129.png-76023c6981cb9f109d776bad48a9
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair130.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair130.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair130.png-4a9ff154e29748abfd8ab4e18900
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair131.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair131.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair131.png-588cd4c2e965b0b6d1eca7d6ebb9
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair132.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair132.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair132.png-32d790aebeca84d1776b09320e45
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair133.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair133.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair133.png-df6f60d3187a9a798689708d618e
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair134.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair134.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair134.png-9bf371c05d1571fd22594084954a
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair135.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair135.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair135.png-5270eb4aab116f92e78e16b33eb3
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair136.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair136.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair136.png-8861cf3955f9e62af26f79b7be99
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair137.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair137.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair137.png-bb959b20d79f3481ac5198802fb2
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair138.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair138.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair138.png-ace0a633d8130380c72baec7708c
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair139.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair139.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair139.png-54da41e09a4d70157b1ba751e435
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair140.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair140.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair140.png-08d9ffa5a4957c94fac22ba478da
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair141.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair141.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair141.png-243b0128a7e060ed6b0e041f9935
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair142.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair142.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair142.png-4f84c08785ec5095cb83795cfa8a
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair143.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair143.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair143.png-122e945c49605c0b9831f6d3ae2e
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair144.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair144.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair144.png-92f8025a6f400ef547c13e740cbb
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair145.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair145.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair145.png-1b55b8ef595c1073b8ef885e77ea
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair146.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair146.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair146.png-9ac02dc07cc55012ebf792c53351
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair147.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair147.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair147.png-3abf54191bb993abd598acf446a8
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair148.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair148.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair148.png-79bcaa150e79e49aeb70dff57ef7
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair149.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair149.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair149.png-712c5a36be06d8bc7ded67689d22
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair150.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair150.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair150.png-ee096710a1906e6db25592b2a060
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair151.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair151.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair151.png-f2217b9f34d77a1f7712fd23f669
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair152.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair152.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair152.png-81071cab86fdcc7d5951c1c7ad51
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair153.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair153.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair153.png-554fa2b78c6dec1939dd90b53ff9
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair154.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair154.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair154.png-3f06324c023b75bcfb7e8305e7aa
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair155.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair155.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair155.png-f2480038aa5c6fdc1e32e95f3f4a
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair156.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair156.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair156.png-27be7756484caebe4e62308154af
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair157.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair157.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair157.png-5a23dc3a63293e38908ca350ab5b
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair158.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair158.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair158.png-aa993da6843b8c59ea0d78997334
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair159.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair159.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair159.png-4840d4730927b395c74b93d04f04
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair160.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair160.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair160.png-19f5c4a214292d7d8b3c8d35917e
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair161.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair161.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair161.png-08da49fdcbafc32d62728188f66f
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair162.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair162.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair162.png-7f16c9152d8b250263c629009f03
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair163.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair163.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair163.png-0723c54e9eb316ec67c5c3166fc8
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair164.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair164.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair164.png-0258a446de87965d6b1e92add32c
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair165.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair165.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair165.png-0fad8c04cbf142c5bf300db9bbaa
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair166.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair166.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair166.png-5ed6e668fb7a68f444f4b99cc870
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair167.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair167.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair167.png-5fd1ef99a682499eb4eda8f4e062
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair168.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair168.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair168.png-6ca6c5c932909f0eef8f22b3e55f
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair169.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair169.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair169.png-a32b7ff04d1d06cd4885d9df8455
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair170.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair170.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair170.png-dfd4c35f67a82513b1707815178d
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair171.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair171.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair171.png-acd645545c5a365f6ef3fe1dad92
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair172.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair172.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair172.png-213418886c0e1177d91817604802
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair173.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair173.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair173.png-6d727fa6aab323b1e8b26219f8be
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair174.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair174.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair174.png-ab9adfdd3f7e98ace38fc874a3eb
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair175.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair175.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair175.png-2583f264cb7da0cdf54bbb957b29
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair176.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair176.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair176.png-aee764045f6a64db5945466e60b8
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair177.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair177.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair177.png-447b78a2c53c0ed4c6faa8e5d9be
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair178.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair178.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair178.png-73deefd0b44950e300b7b3638adb
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair179.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair179.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair179.png-c0ac1cac013ca71722c320523703
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair180.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair180.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair180.png-038b2cb84807f881a4f399d58bf9
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair181.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair181.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair181.png-6b8a9d9cf9fc0603f009bcadf956
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair182.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair182.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair182.png-6daff4b0d189eee3aba8a64b7dd1
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair183.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair183.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair183.png-fef8f514c4503873a724d1ac33f8
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair184.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair184.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair184.png-cc04a9bce658778e65fae9df3d5a
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair185.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair185.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair185.png-bbe08187c67c8719c3373465ca1b
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair186.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair186.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair186.png-820b0b2f8b09cb03aac9c500e7b2
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair187.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair187.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair187.png-e88b0fa1a31bc456a9e840216813
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair188.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair188.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair188.png-644fee7281e277c3d02fa250dbd6
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair189.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair189.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair189.png-652b08879d8711a8d37f756f3a84
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair190.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair190.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair190.png-a760b05ead3275dece042c5dfc36
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair191.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair191.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair191.png-913ebb56b1a3063d4db4a69fc0a3
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair192.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair192.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair192.png-6efd6476c2d553535c0b1a8c9499
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair193.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair193.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair193.png-80d404ea5531fd8d3ef22da04b6f
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair194.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair194.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair194.png-0da982c9bef412bed684427ed487
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair195.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair195.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair195.png-2bc39fa9eb979b7bfd40511b0842
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair196.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair196.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair196.png-fd4d6c3d13528cf473fa4125154f
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair197.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair197.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair197.png-01f3ebc1db01c79bbd6eb82036a7
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair198.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair198.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair198.png-fef399dc780fdf5c3f6e78716abe
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair199.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair199.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair199.png-3d940f627eceed6d108a4dd5db3e
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/assets/ui/kenney-crosshairs/crosshair200.png.import
+++ b/assets/ui/kenney-crosshairs/crosshair200.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/crosshair200.png-97bd78f5d4e0b9bfd2d686990f91
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/icon.svg.import
+++ b/icon.svg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.cte
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/project.godot
+++ b/project.godot
@@ -200,6 +200,11 @@ unit_groups_access_9={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":57,"key_label":0,"unicode":57,"echo":false,"script":null)
 ]
 }
+toggle_play_mode={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":79,"key_label":0,"unicode":111,"echo":false,"script":null)
+]
+}
 
 [internationalization]
 

--- a/source/Constants.gd
+++ b/source/Constants.gd
@@ -6,6 +6,11 @@ enum PlayerType {
 	SIMPLE_CLAIRVOYANT_AI = 2,
 }
 
+enum PlayModes {
+	Operator = 0,
+	Pilot = 1,
+}
+
 
 class Match:
 	extends "res://source/match/MatchConstants.gd"

--- a/source/Globals.gd
+++ b/source/Globals.gd
@@ -8,7 +8,10 @@ var options = (
 	else Options.new()
 )
 var god_mode = false
+var play_mode = Constants.PlayModes.Pilot
 var cache = {}
+
+var player
 
 
 func _unhandled_input(event):

--- a/source/match/FpsCamera3D.gd
+++ b/source/match/FpsCamera3D.gd
@@ -1,0 +1,27 @@
+extends Camera3D
+
+@export var mouse_sensitivity = 0.0015
+@export var reference_plane_for_rotation = Plane(Vector3.UP, 0.0)
+
+@onready var _unit = get_parent()
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass
+
+func _unhandled_input(event):
+	if current and event is InputEventMouseMotion:
+		rotation.x -= event.relative.y * mouse_sensitivity
+		rotation_degrees.x = clamp(rotation_degrees.x, -90.0, 30.0)
+		_unit.rotation.y -= event.relative.x * mouse_sensitivity
+
+func get_ray_intersection(mouse_pos):
+	return get_ray_intersection_with_plane(mouse_pos, reference_plane_for_rotation)
+
+func get_ray_intersection_with_plane(mouse_pos, plane):
+	return plane.intersects_ray(project_ray_origin(mouse_pos), project_ray_normal(mouse_pos))

--- a/source/match/IsometricCamera3D.gd
+++ b/source/match/IsometricCamera3D.gd
@@ -35,7 +35,7 @@ func _ready():
 
 
 func _physics_process(delta):
-	if _movement_vector_2d != Vector2(0, 0):
+	if current and _movement_vector_2d != Vector2(0, 0):
 		var real_delta = delta / Engine.time_scale
 		var scaled_movement_vector_2d = (
 			_movement_vector_2d.normalized()
@@ -57,6 +57,9 @@ func _process(_delta):
 
 
 func _unhandled_input(event):
+	if not current:
+		return
+		
 	if event is InputEventMouseButton:
 		if event.is_pressed() and event.button_index == MOUSE_BUTTON_WHEEL_UP:
 			_zoom_in()

--- a/source/match/Match.gd
+++ b/source/match/Match.gd
@@ -8,6 +8,7 @@ const Human = preload("res://source/match/players/human/Human.gd")
 const CommandCenter = preload("res://source/match/units/CommandCenter.tscn")
 const Drone = preload("res://source/match/units/Drone.tscn")
 const Worker = preload("res://source/match/units/Worker.tscn")
+const Pilot = preload("res://source/match/units/Pilot.tscn")
 
 @export var settings: Resource = null
 
@@ -26,6 +27,7 @@ var visible_players = null:
 @onready var _camera = $IsometricCamera3D
 @onready var _players = $Players
 @onready var _terrain = $Terrain
+@onready var _SH = $Handlers/PlayModeSwitchHandler
 
 
 func _enter_tree():
@@ -126,6 +128,11 @@ func _setup_player_units():
 			_spawn_player_units(
 				player, map.find_child("SpawnPoints").get_child(player_index).global_transform
 			)
+		if player is Human:
+			Globals.player = player
+			var pilot = Pilot.instantiate()
+			_setup_and_spawn_unit(pilot, map.find_child("SpawnPoints").get_child(player_index).global_transform.translated(Vector3(-3, 0, -3)), player)
+			_SH.pilot_unit(pilot)
 
 
 func _spawn_player_units(player, spawn_transform):

--- a/source/match/Match.tscn
+++ b/source/match/Match.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=44 format=3 uid="uid://camns8fqod8d4"]
+[gd_scene load_steps=45 format=3 uid="uid://camns8fqod8d4"]
 
 [ext_resource type="Script" path="res://source/match/Match.gd" id="1_1555u"]
 [ext_resource type="Script" path="res://source/match/IsometricCamera3D.gd" id="1_qb2ry"]
@@ -28,6 +28,7 @@
 [ext_resource type="PackedScene" uid="uid://pi813oou7xim" path="res://source/match/handlers/DoubleClickUnitSelectionHandler.tscn" id="25_ldkhw"]
 [ext_resource type="PackedScene" uid="uid://yn470qvc3eak" path="res://source/match/handlers/MatchEndHandler.tscn" id="26_4d7im"]
 [ext_resource type="PackedScene" uid="uid://ck6vrgdyg7hja" path="res://source/match/handlers/UnitGroupSelectionHandler.tscn" id="27_j2drv"]
+[ext_resource type="PackedScene" uid="uid://cq6ebbwygfl6" path="res://source/match/handlers/PlayModeSwitchHandler.tscn" id="30_aft50"]
 [ext_resource type="PackedScene" uid="uid://b8p6lcwubx1tp" path="res://source/match/handlers/UnitVisibilityHandler.tscn" id="32_fci1c"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_ysb0j"]
@@ -397,6 +398,32 @@ layout_mode = 2
 layout_mode = 2
 size_flags_horizontal = 8
 
+[node name="PlayMode" type="MarginContainer" parent="HUD"]
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -20.0
+offset_top = -40.0
+offset_right = 20.0
+grow_horizontal = 2
+grow_vertical = 0
+
+[node name="Panel" type="Panel" parent="HUD/PlayMode"]
+layout_mode = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="HUD/PlayMode"]
+layout_mode = 2
+
+[node name="Pilotable" type="Label" parent="HUD/PlayMode/VBoxContainer"]
+layout_mode = 2
+text = "Pilotable: "
+
+[node name="CC" type="Label" parent="HUD/PlayMode/VBoxContainer"]
+layout_mode = 2
+text = "CommandCenter: "
+
 [node name="Menu" parent="." instance=ExtResource("22_ofmlu")]
 visible = false
 
@@ -423,3 +450,5 @@ rectangular_selection_3d = NodePath("../../RectangularSelection3D")
 visible = false
 
 [node name="UnitVisibilityHandler" parent="Handlers" instance=ExtResource("32_fci1c")]
+
+[node name="PlayModeSwitchHandler" parent="Handlers" instance=ExtResource("30_aft50")]

--- a/source/match/MatchConstants.gd
+++ b/source/match/MatchConstants.gd
@@ -128,6 +128,12 @@ class Units:
 		},
 	}
 	const DEFAULT_PROPERTIES = {
+		"res://source/match/units/Pilot.tscn":
+		{
+			"sight_range": 10.0,
+			"hp": 3,
+			"hp_max": 3,
+		},
 		"res://source/match/units/Drone.tscn":
 		{
 			"sight_range": 10.0,

--- a/source/match/handlers/PlayModeSwitchHandler.gd
+++ b/source/match/handlers/PlayModeSwitchHandler.gd
@@ -1,0 +1,53 @@
+extends Node3D
+
+const PilotScene = preload("res://source/match/units/Pilot.tscn")
+const Pilot = preload("res://source/match/units/Pilot.gd")
+
+var pilotable = null
+var command_center = null: set = _set_command_center
+func _set_command_center(value):
+	if value != null:
+		_last_command_center = value
+	command_center = value
+
+var _last_command_center = null
+var _piloted = null
+@onready var _match = find_parent("Match")
+
+func _unhandled_input(event):
+	if event.is_action_pressed("toggle_play_mode"):
+		_toggle_play_mode()
+
+func _toggle_play_mode():
+	# playing in FPS
+	if Globals.play_mode == Constants.PlayModes.Pilot:
+		if _piloted is Pilot:
+			# enter ship
+			if pilotable != null:
+				_piloted.queue_free()
+				pilot_unit(pilotable)
+			# enter commandCenter
+			elif command_center != null:
+				Globals.play_mode = Constants.PlayModes.Operator
+				_match.find_child("IsometricCamera3D").make_current()
+				_piloted.queue_free()
+		else:
+			# exit ship
+			var new_pilot = PilotScene.instantiate()
+			_match._setup_and_spawn_unit(new_pilot, _piloted.global_transform.translated(Vector3(-1, 0, -1)), Globals.player)
+			_piloted.find_child("Movement").piloted = false
+			pilot_unit(new_pilot)
+			
+	# playing as operator
+	else:
+		# exit commandCenter
+		if _last_command_center != null:
+			var new_pilot = PilotScene.instantiate()
+			_match._setup_and_spawn_unit(new_pilot, _last_command_center.global_transform.translated(Vector3(-1, 0, -1)), Globals.player)
+			pilot_unit(new_pilot)
+			Globals.play_mode = Constants.PlayModes.Pilot
+
+func pilot_unit(unit):
+	unit.find_child("Camera3D").make_current()
+	unit.find_child("Movement").piloted = true
+	_piloted = unit

--- a/source/match/handlers/PlayModeSwitchHandler.tscn
+++ b/source/match/handlers/PlayModeSwitchHandler.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://cq6ebbwygfl6"]
+
+[ext_resource type="Script" path="res://source/match/handlers/PlayModeSwitchHandler.gd" id="1_b2tl0"]
+
+[node name="PlayModeSwitchHandler" type="Node3D"]
+script = ExtResource("1_b2tl0")

--- a/source/match/hud/Minimap.gd
+++ b/source/match/hud/Minimap.gd
@@ -91,21 +91,40 @@ func _update_camera_indicator():
 		Vector2(viewport.size.x, 0),
 		Vector2.ZERO
 	]
+	
+	var mapSize = find_child("MinimapViewport").size
+	var default_collisions = [
+		Vector2i(0,0),
+		mapSize * Vector2i(0,1),
+		mapSize,
+		mapSize * Vector2i(1,0),
+		Vector2i(0,0),
+	]
+	
 	for index in range(camera_corners.size()):
-		var corner_mapped_to_3d_position_on_ground_level = (
-			GROUND_LEVEL_PLANE.intersects_ray(
-				camera.project_ray_origin(camera_corners[index]),
-				camera.project_ray_normal(camera_corners[index])
+		var ray_origin = camera.project_ray_origin(camera_corners[index])
+		var ray_normal = camera.project_ray_normal(camera_corners[index])
+		var ground_intersect = GROUND_LEVEL_PLANE.intersects_ray(
+				ray_origin,
+				ray_normal
 			)
-			* MINIMAP_PIXELS_PER_WORLD_METER
-		)
-		_camera_indicator.set_point_position(
-			index,
-			Vector2(
-				corner_mapped_to_3d_position_on_ground_level.x,
-				corner_mapped_to_3d_position_on_ground_level.z
+		if ground_intersect == null:
+			_camera_indicator.set_point_position(
+				index,
+				default_collisions[index]
 			)
-		)
+		else:
+			var corner_mapped_to_3d_position_on_ground_level = (
+				ground_intersect
+				* MINIMAP_PIXELS_PER_WORLD_METER
+			)
+			_camera_indicator.set_point_position(
+				index,
+				Vector2(
+					corner_mapped_to_3d_position_on_ground_level.x,
+					corner_mapped_to_3d_position_on_ground_level.z
+				)
+			)
 
 
 func _texture_rect_position_to_world_position(position_2d_within_texture_rect):

--- a/source/match/hud/Minimap.gd
+++ b/source/match/hud/Minimap.gd
@@ -92,15 +92,6 @@ func _update_camera_indicator():
 		Vector2.ZERO
 	]
 	
-	var mapSize = find_child("MinimapViewport").size
-	var default_collisions = [
-		Vector2i(0,0),
-		mapSize * Vector2i(0,1),
-		mapSize,
-		mapSize * Vector2i(1,0),
-		Vector2i(0,0),
-	]
-	
 	for index in range(camera_corners.size()):
 		var ray_origin = camera.project_ray_origin(camera_corners[index])
 		var ray_normal = camera.project_ray_normal(camera_corners[index])
@@ -109,9 +100,10 @@ func _update_camera_indicator():
 				ray_normal
 			)
 		if ground_intersect == null:
+			var maxView = ray_origin+ray_normal*10.0
 			_camera_indicator.set_point_position(
 				index,
-				default_collisions[index]
+				Vector2(maxView.x,maxView.z) * MINIMAP_PIXELS_PER_WORLD_METER
 			)
 		else:
 			var corner_mapped_to_3d_position_on_ground_level = (

--- a/source/match/units/Drone.tscn
+++ b/source/match/units/Drone.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://0gow0ughqu8u"]
+[gd_scene load_steps=12 format=3 uid="uid://0gow0ughqu8u"]
 
 [ext_resource type="Script" path="res://source/match/units/Drone.gd" id="1_5qo4j"]
 [ext_resource type="PackedScene" uid="uid://cgsi062w5fjia" path="res://source/match/units/traits/Highlight.tscn" id="1_44soy"]
@@ -8,6 +8,8 @@
 [ext_resource type="PackedScene" uid="uid://cmvtt1w71wso2" path="res://assets/models/kenney-spacekit/craft_speederA.glb" id="6_88s7t"]
 [ext_resource type="PackedScene" uid="uid://b1r67ex7h3veu" path="res://source/match/units/traits/AirToTerrainMarker.tscn" id="7_hxqr1"]
 [ext_resource type="PackedScene" uid="uid://d4cm4yhtf11ur" path="res://source/match/units/traits/Targetability.tscn" id="8_hsorq"]
+[ext_resource type="Script" path="res://source/match/FpsCamera3D.gd" id="9_rjp8e"]
+[ext_resource type="PackedScene" uid="uid://ccwgdcyfg8job" path="res://source/match/units/traits/Pilotable.tscn" id="10_jkjuv"]
 
 [sub_resource type="CylinderShape3D" id="CylinderShape3D_2f8yw"]
 height = 0.3
@@ -49,3 +51,9 @@ size = Vector2(100, 10)
 
 [node name="Targetability" parent="." instance=ExtResource("8_hsorq")]
 radius = 0.6
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.224432, -0.102811)
+script = ExtResource("9_rjp8e")
+
+[node name="Pilotable" parent="." instance=ExtResource("10_jkjuv")]

--- a/source/match/units/Helicopter.tscn
+++ b/source/match/units/Helicopter.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://e7tko4kpeiau"]
+[gd_scene load_steps=16 format=3 uid="uid://e7tko4kpeiau"]
 
 [ext_resource type="Script" path="res://source/match/units/Helicopter.gd" id="1_4fna5"]
 [ext_resource type="PackedScene" uid="uid://cgsi062w5fjia" path="res://source/match/units/traits/Highlight.tscn" id="1_nqs7t"]
@@ -8,6 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://d1ekv61cse3bl" path="res://assets/models/kenney-spacekit/craft_racer.glb" id="6_3gekj"]
 [ext_resource type="PackedScene" uid="uid://b1r67ex7h3veu" path="res://source/match/units/traits/AirToTerrainMarker.tscn" id="7_5wh2l"]
 [ext_resource type="PackedScene" uid="uid://d4cm4yhtf11ur" path="res://source/match/units/traits/Targetability.tscn" id="8_ib4xd"]
+[ext_resource type="Script" path="res://source/match/FpsCamera3D.gd" id="9_sbnro"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_io5xm"]
 resource_name = "metal"
@@ -95,3 +96,7 @@ size = Vector2(140, 10)
 
 [node name="Targetability" parent="." instance=ExtResource("8_ib4xd")]
 radius = 0.8
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.452916, -0.386677)
+script = ExtResource("9_sbnro")

--- a/source/match/units/Pilot.gd
+++ b/source/match/units/Pilot.gd
@@ -1,0 +1,2 @@
+extends "res://source/match/units/Unit.gd"
+

--- a/source/match/units/Pilot.tscn
+++ b/source/match/units/Pilot.tscn
@@ -1,0 +1,60 @@
+[gd_scene load_steps=11 format=3 uid="uid://bmrlqm21kb1v7"]
+
+[ext_resource type="Script" path="res://source/match/units/Pilot.gd" id="1_irnbs"]
+[ext_resource type="PackedScene" uid="uid://cgsi062w5fjia" path="res://source/match/units/traits/Highlight.tscn" id="3_hn016"]
+[ext_resource type="PackedScene" uid="uid://3c1h14nqdumt" path="res://source/match/units/traits/Selection.tscn" id="4_fugyd"]
+[ext_resource type="PackedScene" uid="uid://ivlo0e66qocl" path="res://source/match/units/traits/Movement.tscn" id="5_7hps5"]
+[ext_resource type="PackedScene" uid="uid://c3ssj2p6voauk" path="res://source/match/units/traits/HealthBar.tscn" id="6_u5bbk"]
+[ext_resource type="PackedScene" uid="uid://d4cm4yhtf11ur" path="res://source/match/units/traits/Targetability.tscn" id="8_7oqft"]
+[ext_resource type="PackedScene" uid="uid://ccwgdcyfg8job" path="res://source/match/units/traits/Pilotable.tscn" id="8_lcav2"]
+[ext_resource type="Script" path="res://source/match/FpsCamera3D.gd" id="9_lj8hp"]
+
+[sub_resource type="SphereMesh" id="SphereMesh_hcmi7"]
+radius = 0.25
+height = 0.5
+
+[sub_resource type="CylinderShape3D" id="CylinderShape3D_2f8yw"]
+height = 0.5
+radius = 0.25
+
+[node name="Pilot" type="Area3D"]
+collision_layer = 6
+collision_mask = 0
+script = ExtResource("1_irnbs")
+
+[node name="Geometry" type="Node3D" parent="."]
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Geometry"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
+mesh = SubResource("SphereMesh_hcmi7")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
+shape = SubResource("CylinderShape3D_2f8yw")
+
+[node name="Highlight" parent="." instance=ExtResource("3_hn016")]
+radius = 0.6
+
+[node name="Selection" parent="." instance=ExtResource("4_fugyd")]
+radius = 0.6
+
+[node name="Movement" parent="." instance=ExtResource("5_7hps5")]
+path_desired_distance = 0.1
+target_desired_distance = 0.1
+path_height_offset = 0.5
+radius = 0.6
+neighbor_distance = 8.0
+max_neighbors = 40
+
+[node name="HealthBar" parent="." instance=ExtResource("6_u5bbk")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.7, 0)
+size = Vector2(100, 10)
+
+[node name="Targetability" parent="." instance=ExtResource("8_7oqft")]
+radius = 0.6
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, -0.26)
+script = ExtResource("9_lj8hp")
+
+[node name="Pilotable" parent="." instance=ExtResource("8_lcav2")]

--- a/source/match/units/Pilot.tscn.bak
+++ b/source/match/units/Pilot.tscn.bak
@@ -1,0 +1,60 @@
+[gd_scene load_steps=11 format=3 uid="uid://bmrlqm21kb1v7"]
+
+[ext_resource type="Script" path="res://source/match/units/Pilot.gd" id="1_irnbs"]
+[ext_resource type="PackedScene" uid="uid://cgsi062w5fjia" path="res://source/match/units/traits/Highlight.tscn" id="3_hn016"]
+[ext_resource type="PackedScene" uid="uid://3c1h14nqdumt" path="res://source/match/units/traits/Selection.tscn" id="4_fugyd"]
+[ext_resource type="PackedScene" uid="uid://ivlo0e66qocl" path="res://source/match/units/traits/Movement.tscn" id="5_7hps5"]
+[ext_resource type="PackedScene" uid="uid://c3ssj2p6voauk" path="res://source/match/units/traits/HealthBar.tscn" id="6_u5bbk"]
+[ext_resource type="PackedScene" uid="uid://d4cm4yhtf11ur" path="res://source/match/units/traits/Targetability.tscn" id="8_7oqft"]
+[ext_resource type="Script" path="res://source/match/FpsCamera3D.gd" id="9_lj8hp"]
+[ext_resource type="PackedScene" uid="uid://cjl1eo208f7dy" path="res://source/match/units/traits/Pilotable.tscn" id="10_spaqs"]
+
+[sub_resource type="SphereMesh" id="SphereMesh_hcmi7"]
+radius = 0.25
+height = 0.5
+
+[sub_resource type="CylinderShape3D" id="CylinderShape3D_2f8yw"]
+height = 0.3
+
+[node name="Pilot" type="Area3D"]
+collision_layer = 4
+collision_mask = 0
+script = ExtResource("1_irnbs")
+
+[node name="Geometry" type="Node3D" parent="."]
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Geometry"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
+mesh = SubResource("SphereMesh_hcmi7")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.15, 0)
+shape = SubResource("CylinderShape3D_2f8yw")
+
+[node name="Highlight" parent="." instance=ExtResource("3_hn016")]
+radius = 0.6
+
+[node name="Selection" parent="." instance=ExtResource("4_fugyd")]
+radius = 0.6
+
+[node name="Movement" parent="." instance=ExtResource("5_7hps5")]
+path_desired_distance = 0.1
+target_desired_distance = 0.1
+path_height_offset = 0.5
+radius = 0.6
+neighbor_distance = 8.0
+max_neighbors = 40
+domain = 0
+
+[node name="HealthBar" parent="." instance=ExtResource("6_u5bbk")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.7, 0)
+size = Vector2(100, 10)
+
+[node name="Targetability" parent="." instance=ExtResource("8_7oqft")]
+radius = 0.6
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, -0.26)
+script = ExtResource("9_lj8hp")
+
+[node name="Pilotable" parent="." instance=ExtResource("10_spaqs")]

--- a/source/match/units/Pilot.tscn.bak2
+++ b/source/match/units/Pilot.tscn.bak2
@@ -1,0 +1,57 @@
+[gd_scene load_steps=10 format=3 uid="uid://bmrlqm21kb1v7"]
+
+[ext_resource type="Script" path="res://source/match/units/Pilot.gd" id="1_irnbs"]
+[ext_resource type="PackedScene" uid="uid://cgsi062w5fjia" path="res://source/match/units/traits/Highlight.tscn" id="3_hn016"]
+[ext_resource type="PackedScene" uid="uid://3c1h14nqdumt" path="res://source/match/units/traits/Selection.tscn" id="4_fugyd"]
+[ext_resource type="PackedScene" uid="uid://ivlo0e66qocl" path="res://source/match/units/traits/Movement.tscn" id="5_7hps5"]
+[ext_resource type="PackedScene" uid="uid://c3ssj2p6voauk" path="res://source/match/units/traits/HealthBar.tscn" id="6_u5bbk"]
+[ext_resource type="PackedScene" uid="uid://d4cm4yhtf11ur" path="res://source/match/units/traits/Targetability.tscn" id="8_7oqft"]
+[ext_resource type="Script" path="res://source/match/FpsCamera3D.gd" id="9_lj8hp"]
+
+[sub_resource type="SphereMesh" id="SphereMesh_hcmi7"]
+radius = 0.25
+height = 0.5
+
+[sub_resource type="CylinderShape3D" id="CylinderShape3D_2f8yw"]
+height = 0.3
+
+[node name="Pilot" type="Area3D"]
+collision_layer = 4
+collision_mask = 0
+script = ExtResource("1_irnbs")
+
+[node name="Geometry" type="Node3D" parent="."]
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Geometry"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
+mesh = SubResource("SphereMesh_hcmi7")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.15, 0)
+shape = SubResource("CylinderShape3D_2f8yw")
+
+[node name="Highlight" parent="." instance=ExtResource("3_hn016")]
+radius = 0.6
+
+[node name="Selection" parent="." instance=ExtResource("4_fugyd")]
+radius = 0.6
+
+[node name="Movement" parent="." instance=ExtResource("5_7hps5")]
+path_desired_distance = 0.1
+target_desired_distance = 0.1
+path_height_offset = 0.5
+radius = 0.6
+neighbor_distance = 8.0
+max_neighbors = 40
+domain = 0
+
+[node name="HealthBar" parent="." instance=ExtResource("6_u5bbk")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.7, 0)
+size = Vector2(100, 10)
+
+[node name="Targetability" parent="." instance=ExtResource("8_7oqft")]
+radius = 0.6
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, -0.26)
+script = ExtResource("9_lj8hp")

--- a/source/match/units/Tank.tscn
+++ b/source/match/units/Tank.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://i58ffvwxbbwm"]
+[gd_scene load_steps=11 format=3 uid="uid://i58ffvwxbbwm"]
 
 [ext_resource type="PackedScene" uid="uid://cgsi062w5fjia" path="res://source/match/units/traits/Highlight.tscn" id="1_n4t54"]
 [ext_resource type="Script" path="res://source/match/units/Tank.gd" id="1_npbka"]
@@ -8,6 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://chmayxp3itowx" path="res://assets/models/kenney-spacekit/craft_miner.glb" id="3_putds"]
 [ext_resource type="PackedScene" uid="uid://c3ssj2p6voauk" path="res://source/match/units/traits/HealthBar.tscn" id="4_7l0rt"]
 [ext_resource type="PackedScene" uid="uid://d4cm4yhtf11ur" path="res://source/match/units/traits/Targetability.tscn" id="8_ca2nt"]
+[ext_resource type="Script" path="res://source/match/FpsCamera3D.gd" id="9_qyt8g"]
 
 [sub_resource type="CylinderShape3D" id="CylinderShape3D_sjc11"]
 height = 0.6
@@ -60,3 +61,7 @@ size = Vector2(160, 10)
 [node name="Targetability" parent="." instance=ExtResource("8_ca2nt")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.05, 0)
 radius = 0.9
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.675637, -0.431718)
+script = ExtResource("9_qyt8g")

--- a/source/match/units/traits/Pilotable.gd
+++ b/source/match/units/traits/Pilotable.gd
@@ -1,0 +1,35 @@
+extends Node3D
+
+const Pilot = preload("res://source/match/units/Pilot.gd")
+const CommandCenter = preload("res://source/match/units/CommandCenter.gd")
+
+@onready var _unit = get_parent()
+@onready var _movement = _unit.find_child("Movement")
+@onready var _area = find_child("Area3D")
+@onready var _UI = find_parent("Match").find_child("PlayMode")
+@onready var _SH = find_parent("Match").find_child("PlayModeSwitchHandler")
+
+func _ready():
+	print("setup pilotable")
+	if _unit is Pilot:
+		_area.connect("area_entered", _on_area_entered)
+		_area.connect("area_exited", _on_area_exited)
+		print("pilot connected")
+	
+func _on_area_entered(area):
+	if area == _unit or area.player != Globals.player:
+		return
+	if area.find_child("Pilotable") != null:
+		_SH.pilotable = area
+		_UI.find_child("Pilotable").text = "Pilotable: "+str(area)
+	elif area is CommandCenter:
+		_SH.command_center = area
+		_UI.find_child("CC").text = "CommandCenter: "+str(area)
+
+func _on_area_exited(area):
+	if area == _SH.pilotable:
+		_SH.pilotable = null
+		_UI.find_child("Pilotable").text = "Pilotable: "
+	elif area == _SH.command_center:
+		_SH.command_center = null
+		_UI.find_child("CC").text = "CommandCenter: "

--- a/source/match/units/traits/Pilotable.tscn
+++ b/source/match/units/traits/Pilotable.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=3 format=3 uid="uid://ccwgdcyfg8job"]
+
+[ext_resource type="Script" path="res://source/match/units/traits/Pilotable.gd" id="1_vuhfg"]
+
+[sub_resource type="CylinderShape3D" id="CylinderShape3D_6hfjy"]
+height = 6.0
+radius = 1.0
+
+[node name="Pilotable" type="Node3D"]
+script = ExtResource("1_vuhfg")
+
+[node name="Area3D" type="Area3D" parent="."]
+collision_layer = 0
+collision_mask = 6
+input_ray_pickable = false
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D"]
+shape = SubResource("CylinderShape3D_6hfjy")

--- a/source/match/utils/UnitPlacementUtils.gd
+++ b/source/match/utils/UnitPlacementUtils.gd
@@ -65,6 +65,7 @@ static func find_valid_position_radially_yet_skip_starting_radius(
 
 static func validate_agent_placement_position(position, radius, existing_units, navigation_map_rid):
 	for existing_unit in existing_units:
+		print(existing_unit.global_position)
 		if (
 			(existing_unit.global_position * Vector3(1, 0, 1)).distance_to(
 				position * Vector3(1, 0, 1)


### PR DESCRIPTION
new entity: Pilot
new unit trait: pilotable
new handler: play_mode switcher

---

this MR add the Possibility to switch to a first person view in a Battlezone kind of fashion.
The Human Player starts the Game as a "Pilot"-Unit and can enter pilotable units.
When entering the Command Center the Player enters RTS mode.
When existing a Unit or the Command Center the Player is represented by a "Pilot"-Unit