### PR TITLE
Update DiagnosticHud.gd

### DIFF
--- a/source/match/debug/DiagnosticHud.gd
+++ b/source/match/debug/DiagnosticHud.gd
@@ -13,4 +13,11 @@ func _unhandled_input(event):
 
 
 func _physics_process(_delta):
-	_fps_label.text = "{0} FPS".format(["%0.1f" % (Performance.get_monitor(Performance.TIME_FPS))])
+	_fps_label.text = "{0} FPS \n".format(["%0.1f" % (Performance.get_monitor(Performance.TIME_FPS))])
+	_fps_label.text += str(OS.get_processor_name()) + " \n"
+	_fps_label.text += str(OS.get_processor_count()) + " Threads Used \n"
+	var MBs = OS.get_static_memory_usage()/int(1000000)
+	_fps_label.text += str(MBs) + " MBs of Memory Used \n"
+	_fps_label.text += str(RenderingServer.get_video_adapter_name()) + " "
+	_fps_label.text += str(RenderingServer.get_video_adapter_vendor()) + " \n"
+	_fps_label.text += "Using " + str(OS.get_name()) + " Operating System"


### PR DESCRIPTION
Added more info on the system usage for issue #107
Diagnostic Hud now should show:
 1. CPU Name
 2. CPU Threads
 3. MBs Memory used
 4. GPU Name
 5. GPU Vendor
 6. OS Name
 Works seamlessly with pre-existing Container